### PR TITLE
ci: bump deploy workflow to v0.0.23

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,7 +198,7 @@ jobs:
     if: github.event_name == 'push'
     needs: [lint, format, unit-test, browser-test, build]
     name: Deploy
-    uses: wajeht/docker-cd-deploy-workflow/.github/workflows/deploy.yaml@v0.0.18
+    uses: wajeht/docker-cd-deploy-workflow/.github/workflows/deploy.yaml@071c1838526ef329aea7f37fe2987f64cd76d714 # v0.0.23
     with:
       app-path: apps/notify
       tag: ${{ needs.build.outputs.tag }}


### PR DESCRIPTION
Bump wajeht/docker-cd-deploy-workflow to v0.0.23 (digest-pinned deploys).